### PR TITLE
fix: specify jasp redirect URI for Spotify auth

### DIFF
--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -18,7 +18,8 @@ export const useSpotifyAuth = () => {
       scopes: ['user-read-email', 'playlist-modify-public', 'playlist-modify-private'],
       usePKCE: true,
       redirectUri: makeRedirectUri({
-        native: 'jasp://redirect',
+        scheme: 'jasp',
+        path: 'redirect',
       }),
     },
     discovery


### PR DESCRIPTION
## Summary
- configure Spotify auth to use `jasp://redirect` as the redirect URI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f1784fa18832bbaf82574311bceac