### PR TITLE
feat: show Spotify profile and playlists on home screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,17 +1,63 @@
 
-import { Button, StyleSheet, Text, View } from 'react-native';
+import {
+  Button,
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useEffect, useState } from 'react';
 import { useSpotifyAuth } from '../hooks/useSpotifyAuth';
 
 export default function HomeScreen() {
-  const { accessToken, promptAsync } = useSpotifyAuth();
+  const { accessToken, promptAsync, logout } = useSpotifyAuth();
+  const [profile, setProfile] = useState<any | null>(null);
+  const [playlists, setPlaylists] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (accessToken) {
+      fetch('https://api.spotify.com/v1/me', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+        .then((res) => res.json())
+        .then(setProfile)
+        .catch(console.error);
+      fetch('https://api.spotify.com/v1/me/playlists', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+        .then((res) => res.json())
+        .then((data) => setPlaylists(data.items || []))
+        .catch(console.error);
+    }
+  }, [accessToken]);
+
+  if (!accessToken) {
+    return (
+      <View style={styles.container}>
+        <Button title="Login with Spotify" onPress={() => promptAsync()} />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
-      {accessToken ? (
-        <Text>Logged In</Text>
-      ) : (
-        <Button title="Login with Spotify" onPress={() => promptAsync()} />
+      {profile && (
+        <>
+          <Image
+            source={{ uri: profile.images?.[0]?.url }}
+            style={styles.avatar}
+          />
+          <Text style={styles.username}>{profile.display_name}</Text>
+        </>
       )}
+      <FlatList
+        data={playlists}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <Text>{item.name}</Text>}
+        style={styles.playlists}
+      />
+      <Button title="Logout" onPress={logout} />
     </View>
   );
 }
@@ -21,5 +67,22 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    marginBottom: 16,
+  },
+  username: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  playlists: {
+    alignSelf: 'stretch',
+    marginHorizontal: 20,
+    flexGrow: 0,
+    marginBottom: 20,
   },
 });

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -28,9 +28,33 @@ export const useSpotifyAuth = () => {
   useEffect(() => {
     if (response?.type === 'success') {
       const { code } = response.params;
-      // TODO: exchange code for token
+      const clientId = process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID || '';
+      const clientSecret = process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_SECRET || '';
+      const redirectUri = makeRedirectUri({
+        scheme: 'jasp',
+        path: 'redirect',
+      });
+      const body = `grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(
+        redirectUri
+      )}&client_id=${clientId}&client_secret=${clientSecret}`;
+      fetch(discovery.tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body,
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          setAccessToken(data.access_token || null);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     }
   }, [response]);
 
-  return { accessToken, promptAsync };
+  const logout = () => setAccessToken(null);
+
+  return { accessToken, promptAsync, logout };
 };


### PR DESCRIPTION
## Summary
- show user profile image, name, playlists and logout on Home screen after login
- implement Spotify token exchange and logout helper in auth hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68907a85c068832bb1221e7281d77b1c