### PR TITLE
Persist Spotify token and show user details

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,12 +3,15 @@ import { Button, StyleSheet, Text, View } from 'react-native';
 import { useSpotifyAuth } from '../hooks/useSpotifyAuth';
 
 export default function HomeScreen() {
-  const { accessToken, promptAsync } = useSpotifyAuth();
+  const { accessToken, userName, promptAsync, logout } = useSpotifyAuth();
 
   return (
     <View style={styles.container}>
       {accessToken ? (
-        <Text>Logged In</Text>
+        <>
+          <Text>Welcome, {userName}</Text>
+          <Button title="Logout" onPress={logout} />
+        </>
       ) : (
         <Button title="Login with Spotify" onPress={() => promptAsync()} />
       )}

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -1,7 +1,12 @@
 
 import { useEffect, useState } from 'react';
-import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import {
+  exchangeCodeAsync,
+  makeRedirectUri,
+  useAuthRequest,
+} from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -12,6 +17,7 @@ const discovery = {
 
 export const useSpotifyAuth = () => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [userName, setUserName] = useState<string | null>(null);
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID || '',
@@ -26,11 +32,62 @@ export const useSpotifyAuth = () => {
   );
 
   useEffect(() => {
-    if (response?.type === 'success') {
-      const { code } = response.params;
-      // TODO: exchange code for token
-    }
-  }, [response]);
+    const loadToken = async () => {
+      const storedToken = await AsyncStorage.getItem('spotify_token');
+      if (storedToken) {
+        setAccessToken(storedToken);
+        fetchUserProfile(storedToken);
+      }
+    };
+    loadToken();
+  }, []);
 
-  return { accessToken, promptAsync };
+  const fetchUserProfile = async (token: string) => {
+    try {
+      const res = await fetch('https://api.spotify.com/v1/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setUserName(data.display_name);
+    } catch (e) {
+      console.error('Failed to fetch user profile', e);
+    }
+  };
+
+  useEffect(() => {
+    if (response?.type === 'success' && request) {
+      const { code } = response.params;
+      const getToken = async () => {
+        try {
+          const tokenResult = await exchangeCodeAsync(
+            {
+              clientId: process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID || '',
+              code,
+              redirectUri: makeRedirectUri({
+                scheme: 'jasp',
+                path: 'redirect',
+              }),
+              codeVerifier: request.codeVerifier || '',
+            },
+            discovery
+          );
+          const token = tokenResult.access_token;
+          setAccessToken(token);
+          await AsyncStorage.setItem('spotify_token', token);
+          fetchUserProfile(token);
+        } catch (e) {
+          console.error('Failed to exchange code', e);
+        }
+      };
+      getToken();
+    }
+  }, [response, request]);
+
+  const logout = async () => {
+    await AsyncStorage.removeItem('spotify_token');
+    setAccessToken(null);
+    setUserName(null);
+  };
+
+  return { accessToken, userName, promptAsync, logout };
 };


### PR DESCRIPTION
## Summary
- store Spotify auth token in AsyncStorage and fetch user profile
- greet the logged in user by name and provide a logout button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890d393bc50832b8b0eca6894b61fa9